### PR TITLE
fix: Show site-meta doc in Studio

### DIFF
--- a/sanity/settings/deskStructure.ts
+++ b/sanity/settings/deskStructure.ts
@@ -64,10 +64,11 @@ export const structure = (S) =>
         .title("Rebekah's Old Blogs")
         .icon(FaArchive)
         .child(S.documentTypeList("socialBlog")),
+      S.divider(),
       S.listItem()
         .title("Site Meta")
         .icon(FaChartLine)
-        .child(S.documentTypeList("MetaData")),
+        .child(S.documentTypeList("metadata")),
     ]);
 
 // Customise this function to show the correct URL based on the current document


### PR DESCRIPTION
- refactor(deskStructure.ts): change "MetaData" to "metadata" in S.documentTypeList() method call
- feat(deskStructure.ts): add divider between "Rebekah's Old Blogs" and "Site Meta" sections
- chore: T-10800