### PR TITLE
fix(cli): require build error (TwitterEmbed)

### DIFF
--- a/sanity.cli.ts
+++ b/sanity.cli.ts
@@ -15,5 +15,11 @@ export default defineCliConfig({
       ...prev.define,
       "process.env": {},
     },
+    build: {
+      ...prev.build,
+      commonjsOptions: {
+        transformMixedEsModules: true,
+      },
+    },
   }),
 });

--- a/sanity/schemas/objects/blockContent.jsx
+++ b/sanity/schemas/objects/blockContent.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-filename-extension */
 /* eslint-disable import/no-anonymous-default-export */
 // import TablePreview from "./previews/table";
 import { Stack, Text } from "@sanity/ui";

--- a/sanity/schemas/previews/iframe.jsx
+++ b/sanity/schemas/previews/iframe.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-filename-extension */
 import getVideoId from "get-video-id";
 import React from "react";
 import Iframe from "react-iframe";


### PR DESCRIPTION
- TwitterEmbed was throwing an error because of https://github.com/justinmahar/react-social-media-embed/issues/24
- Fixed the issue by adding Vite's build config