### PR TITLE
- feat: add PlausibleProvider to website layout

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export function middleware(request: NextRequest) {
+    const requestHeaders = new Headers(request.headers)
+    requestHeaders.set('cookie', '')
+    return NextResponse.next({
+        request: {
+            headers: requestHeaders,
+        },
+    })
+}
+
+export const config = {
+    matcher: '/proxy/api/event',
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,8 @@
 /* eslint-disable require-await */
 /** @type {import('next').NextConfig} */
+
+const { withPlausibleProxy } = require("next-plausible");
+
 const commonHeaders = [
   {
     key: "Strict-Transport-Security",
@@ -89,4 +92,4 @@ const nextConfig = {
   },
 };
 
-module.exports = nextConfig;
+module.exports = withPlausibleProxy()(nextConfig);

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "get-video-id": "^3.6.5",
     "ms": "^2.1.3",
     "next": "13.4.4",
+    "next-plausible": "^3.7.2",
     "next-sanity": "^4.3.3",
     "postcss": "8.4.22",
     "react": "18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ dependencies:
   next:
     specifier: 13.4.4
     version: 13.4.4(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
+  next-plausible:
+    specifier: ^3.7.2
+    version: 3.7.2(next@13.4.4)(react-dom@18.2.0)(react@18.2.0)
   next-sanity:
     specifier: ^4.3.3
     version: 4.3.3(@sanity/icons@2.3.1)(@sanity/types@3.12.0)(@sanity/ui@1.3.3)(@types/styled-components@5.1.26)(next@13.4.4)(react@18.2.0)(sanity@3.11.5)(styled-components@5.3.11)
@@ -10507,6 +10510,18 @@ packages:
   /netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
+    dev: false
+
+  /next-plausible@3.7.2(next@13.4.4)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-9PqFiVtD1kZO5gHFYTcgilHhg2WhMzD6I4NK/RUh9DGavD1N11IhNAvyGLFmvB3f4FtHC9IoAsauYDtQBt+riA==}
+    peerDependencies:
+      next: ^11.1.0 || ^12.0.0 || ^13.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      next: 13.4.4(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /next-sanity@4.3.3(@sanity/icons@2.3.1)(@sanity/types@3.12.0)(@sanity/ui@1.3.3)(@types/styled-components@5.1.26)(next@13.4.4)(react@18.2.0)(sanity@3.11.5)(styled-components@5.3.11):

--- a/src/app/(website)/layout.tsx
+++ b/src/app/(website)/layout.tsx
@@ -4,6 +4,7 @@ import "../globals.css";
 
 import { Metadata } from "next";
 import localFont from "next/font/local";
+import PlausibleProvider from "next-plausible";
 import React from "react";
 
 import { SITE_URL } from "@/lib/constants";
@@ -137,6 +138,14 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className={cx("font-sans antialiased", lexend.variable)}>
+      <head>
+        <PlausibleProvider
+          domain="heyrebekah.com"
+          trackOutboundLinks
+          trackFileDownloads
+          taggedEvents
+        />
+      </head>
       <body>{children}</body>
     </html>
   );


### PR DESCRIPTION
- feat: add next-plausible package to dependencies
- feat: add middleware for /proxy/api/event route in middleware.ts to remove proxy cookies
- chore: add next-plausible to next.config.js using withPlausibleProxy()
- chore: Close T-11940