### PR TITLE
T 12188 quick style edits typos

### DIFF
--- a/src/app/(website)/(dashboard)/layout.tsx
+++ b/src/app/(website)/(dashboard)/layout.tsx
@@ -3,9 +3,9 @@ import Link from "next/link";
 import React from "react";
 
 import Container from "@/components/container";
-import LogoImage from "@/public/hey-rebekah-logo.svg";
 import hoverStyles from "@/lib/hover";
 import { cx } from "@/lib/utils";
+import LogoImage from "@/public/hey-rebekah-logo.svg";
 
 function Layout({ children }: { children: React.ReactNode }) {
   return (
@@ -72,7 +72,8 @@ function Footer() {
               {" "}
               BRIL.LA, LLC.
             </Link>
-            &nbsp;All rights reserved.
+            <br className="md:hidden" />
+            &nbsp;All Rights Reserved.
           </p>
         </div>
       </div>

--- a/src/app/(website)/(dashboard)/reader-preferences/preferences.js
+++ b/src/app/(website)/(dashboard)/reader-preferences/preferences.js
@@ -8,7 +8,6 @@ import { useForm } from "react-hook-form";
 import FormProvider, { useFormData } from "@/components/providers/form-context";
 import { GlowingButton, Input, Lead } from "@/components/ui";
 import BackButton, { Checkbox, Radio } from "@/components/ui/forms";
-
 import { getUserInfo, updateUser } from "@/lib/server/actions";
 
 const TopicsArray = [
@@ -132,7 +131,11 @@ function StepOne({ formStep, nextFormStep }) {
           />
 
           <div className="mt-10 flex justify-center">
-            <GlowingButton type="submit" autoWidth disabled={loading}>
+            <GlowingButton
+              type="submit"
+              autoWidth
+              disabled={loading}
+              ariaLabel={loading ? "Please wait..." : "Change my Preferences"}>
               {loading ? "Just a sec..." : "Change my Preferences"}
             </GlowingButton>
           </div>
@@ -193,7 +196,7 @@ function StepTwo({ formStep, nextFormStep }) {
           />
 
           <div className="mt-10 flex justify-center">
-            <GlowingButton type="submit" autoWidth>
+            <GlowingButton ariaLabel="Go to next step" type="submit" autoWidth>
               Next
             </GlowingButton>
           </div>
@@ -348,7 +351,12 @@ function StepFour({ formStep, prevFormStep, nextFormStep }) {
           )}
           <div className="mt-10 flex justify-center">
             <BackButton onClick={prevFormStep} />
-            <GlowingButton type="submit" autoWidth>
+            <GlowingButton
+              type="submit"
+              autoWidth
+              ariaLabel={
+                topicsSelected ? "Go to the next step" : "Skip this step"
+              }>
               {topicsSelected ? "Next" : "Skip"}
             </GlowingButton>
           </div>
@@ -392,7 +400,8 @@ function FormSubmit({ formStep, nextFormStep, prevFormStep }) {
           type="submit"
           autoWidth
           onClick={submitForm}
-          disabled={loading}>
+          disabled={loading}
+          aria-label="Submit form">
           {(loading && "Just a sec...") || "Update my Preferences"}
         </GlowingButton>
       </div>

--- a/src/app/(website)/(dashboard)/signup/page.js
+++ b/src/app/(website)/(dashboard)/signup/page.js
@@ -8,7 +8,7 @@ export default function Page() {
     <>
       <Container large className="">
         <div className="mt-16">
-          <SignupHeader title="Signup for Hey Rebekah" />
+          <SignupHeader title="Sign-Up" />
           <MultiStepForm />
         </div>
       </Container>

--- a/src/app/(website)/(dashboard)/signup/signupform.js
+++ b/src/app/(website)/(dashboard)/signup/signupform.js
@@ -42,7 +42,7 @@ export default function MultiStepForm() {
   return (
     <div className="">
       <FormProvider>
-        <div className="max-w-xl mx-auto">
+        <div className="mx-auto max-w-xl">
           <StepOne
             formStep={formStep}
             prevFormStep={prevFormStep}
@@ -117,7 +117,7 @@ function StepOne({ formStep, nextFormStep }) {
 
   return (
     <div className={formStep === 1 ? "block" : "hidden"}>
-      <p className="mb-10 text-xs leading-6 tracking-wider text-center text-gray-400 uppercase">
+      <p className="mb-10 text-center text-xs uppercase leading-6 tracking-wider text-gray-400">
         Step 1 of 4 | Required
       </p>
       <div className="">
@@ -129,7 +129,7 @@ function StepOne({ formStep, nextFormStep }) {
         <form ref={formRef} noValidate onSubmit={handleSubmit(onSubmit)}>
           <label className="sr-only">Email Address</label>
           <Input
-            className="w-full text-white border-neutral-200/10 bg-slate-900 placeholder:text-gray-600"
+            className="w-full border-neutral-200/10 bg-slate-900 text-white placeholder:text-gray-600"
             name="email"
             type="email"
             required
@@ -147,12 +147,16 @@ function StepOne({ formStep, nextFormStep }) {
             }}
           />
           <ReactTurnstile />
-          <div className="flex justify-center mt-10">
-            <GlowingButton type="submit" autoWidth disabled={loading}>
+          <div className="mt-10 flex justify-center">
+            <GlowingButton
+              ariaLabel="Go to next step"
+              type="submit"
+              autoWidth
+              disabled={loading}>
               {loading ? "Hold on..." : "Next"}
             </GlowingButton>
           </div>
-          <p className="mt-6 text-xs leading-6 text-center text-gray-400">
+          <p className="mt-6 text-center text-xs leading-6 text-gray-400">
             We care about your{" "}
             <Link href="/privacy" className={cx("font-bold", hoverStyles)}>
               privacy
@@ -181,7 +185,7 @@ function StepTwo({ formStep, nextFormStep }) {
 
   return (
     <div className={formStep === 2 ? "block" : "hidden"}>
-      <p className="mb-10 text-xs leading-6 tracking-wider text-center text-gray-400 uppercase">
+      <p className="mb-10 text-center text-xs uppercase leading-6 tracking-wider text-gray-400">
         Step 2 of 4 | Required
       </p>
       <div className="">
@@ -193,7 +197,7 @@ function StepTwo({ formStep, nextFormStep }) {
         <form noValidate onSubmit={handleSubmit(onSubmit)}>
           <label className="sr-only">First Name</label>
           <Input
-            className="w-full text-white border-neutral-200/10 bg-slate-900 placeholder:text-gray-600"
+            className="w-full border-neutral-200/10 bg-slate-900 text-white placeholder:text-gray-600"
             name="firstName"
             type="text"
             required
@@ -208,8 +212,8 @@ function StepTwo({ formStep, nextFormStep }) {
             }}
           />
 
-          <div className="flex justify-center mt-10">
-            <GlowingButton type="submit" autoWidth>
+          <div className="mt-10 flex justify-center">
+            <GlowingButton ariaLabel="Go to next step" type="submit" autoWidth>
               Next
             </GlowingButton>
           </div>
@@ -234,7 +238,7 @@ function StepThree({ formStep, nextFormStep }) {
 
   return (
     <div className={formStep === 3 ? "block" : "hidden"}>
-      <p className="mb-10 text-xs leading-6 tracking-wider text-center text-gray-400 uppercase">
+      <p className="mb-10 text-center text-xs uppercase leading-6 tracking-wider text-gray-400">
         Step 3 of 4 | Required
       </p>
       <div className="">
@@ -270,8 +274,8 @@ function StepThree({ formStep, nextFormStep }) {
             </div>
           )}
 
-          <div className="flex justify-center mt-10">
-            <GlowingButton type="submit" autoWidth>
+          <div className="mt-10 flex justify-center">
+            <GlowingButton ariaLabel="Go to next step" type="submit" autoWidth>
               Next
             </GlowingButton>
           </div>
@@ -317,7 +321,7 @@ function StepFour({ formStep, prevFormStep, nextFormStep }) {
 
   return (
     <div className={formStep === 4 ? "block" : "hidden"}>
-      <p className="mb-10 text-xs leading-6 tracking-wider text-center text-gray-400 uppercase">
+      <p className="mb-10 text-center text-xs uppercase leading-6 tracking-wider text-gray-400">
         Step 4 of 4 | Optional
       </p>
       <div className="">
@@ -352,9 +356,14 @@ function StepFour({ formStep, prevFormStep, nextFormStep }) {
               <small>{errors.topics.message}</small>
             </div>
           )}
-          <div className="flex justify-center mt-10">
+          <div className="mt-10 flex justify-center">
             <BackButton onClick={prevFormStep} />
-            <GlowingButton type="submit" autoWidth>
+            <GlowingButton
+              ariaLabel={
+                topicsSelected ? "Go to the next step" : "Skip this step"
+              }
+              type="submit"
+              autoWidth>
               {topicsSelected ? "Next" : "Skip"}
             </GlowingButton>
           </div>
@@ -394,12 +403,13 @@ function FormSubmit({ formStep, nextFormStep, prevFormStep }) {
         </p>
       </div>
 
-      <div className="flex justify-center mt-10">
+      <div className="mt-10 flex justify-center">
         <GlowingButton
           type="submit"
           autoWidth
           onClick={submitForm}
-          disabled={loading}>
+          disabled={loading}
+          ariaLabel="Submit Form">
           {(loading && "Just a sec...") || "Submit"}
         </GlowingButton>
       </div>

--- a/src/app/(website)/(dashboard)/signup/signupform.js
+++ b/src/app/(website)/(dashboard)/signup/signupform.js
@@ -117,12 +117,10 @@ function StepOne({ formStep, nextFormStep }) {
 
   return (
     <div className={formStep === 1 ? "block" : "hidden"}>
-      <p className="mb-10 text-center text-xs uppercase leading-6 tracking-wider text-gray-400">
-        Step 1 of 4 | Required
-      </p>
       <div className="">
         <Lead className="text-center text-gray-200">
           What{"\u2018"}s your email address?
+          <sup className="text-pink">&nbsp;*</sup>
         </Lead>
       </div>
       <div className="mt-5">
@@ -185,12 +183,9 @@ function StepTwo({ formStep, nextFormStep }) {
 
   return (
     <div className={formStep === 2 ? "block" : "hidden"}>
-      <p className="mb-10 text-center text-xs uppercase leading-6 tracking-wider text-gray-400">
-        Step 2 of 4 | Required
-      </p>
       <div className="">
         <Lead className="text-center text-gray-200">
-          👋🏾 What should we call you?
+          👋🏾 What should we call you?<sup className="text-pink">&nbsp;*</sup>
         </Lead>
       </div>
       <div className="mt-5">
@@ -238,12 +233,10 @@ function StepThree({ formStep, nextFormStep }) {
 
   return (
     <div className={formStep === 3 ? "block" : "hidden"}>
-      <p className="mb-10 text-center text-xs uppercase leading-6 tracking-wider text-gray-400">
-        Step 3 of 4 | Required
-      </p>
       <div className="">
         <Lead className="text-center text-gray-200">
           Tell us your primay topic of inteest, we{"\u2018"}ll filter the rest.
+          <sup className="text-pink">&nbsp;*</sup>
         </Lead>
       </div>
       <div className="mt-5">
@@ -321,9 +314,6 @@ function StepFour({ formStep, prevFormStep, nextFormStep }) {
 
   return (
     <div className={formStep === 4 ? "block" : "hidden"}>
-      <p className="mb-10 text-center text-xs uppercase leading-6 tracking-wider text-gray-400">
-        Step 4 of 4 | Optional
-      </p>
       <div className="">
         <Lead className="text-center text-gray-200">
           Awesome. Select three more topics you{"\u2018"}d like to keep tabs on.

--- a/src/app/(website)/(main)/accessibility/page.tsx
+++ b/src/app/(website)/(main)/accessibility/page.tsx
@@ -1,17 +1,18 @@
 import { PortableText } from "@portabletext/react";
-import { Metadata } from "next";
 
 import Container from "@/components/container";
 import PageHeader from "@/components/sections/pageheader";
 import { Prose } from "@/components/ui";
 import { getLegalPageBySlug } from "@/sanity/client";
+import { Metadata } from "@/types/types";
+
 
 export function generateMetadata(): Metadata {
   const title = "Accessibility";
   const description =
     "Hey Rebekah strives for inclusive design for our readers. We're continually improving but it's a process. Please reach out to us for accessibility issues.";
 
-  const metadata = {
+  const metadata: Metadata = {
     title,
     description,
     openGraph: {
@@ -29,8 +30,14 @@ export function generateMetadata(): Metadata {
   return metadata;
 }
 
+interface Post {
+  name?: string;
+  tldr?: string;
+  content?: any;
+}
+
 export default async function AccessibilityStatement() {
-  const post = await getLegalPageBySlug("accessibility");
+  const post: Post = await getLegalPageBySlug("accessibility");
 
   // Fetch the post data and insert it into the component
   const title = post?.name ?? "Default Title";

--- a/src/app/(website)/(main)/books/[slug]/post.js
+++ b/src/app/(website)/(main)/books/[slug]/post.js
@@ -76,7 +76,7 @@ export default function Post({ post }) {
                   <GlowingButton
                     href={post.bookUrl || "#"}
                     target="_blank"
-                    aria-label="Go to signup form">
+                    aria-label="Go to sign-up form">
                     Get the Book
                   </GlowingButton>
                 </div>

--- a/src/app/(website)/(main)/books/[slug]/post.js
+++ b/src/app/(website)/(main)/books/[slug]/post.js
@@ -73,7 +73,10 @@ export default function Post({ post }) {
                 </div>
 
                 <div className="mt-6">
-                  <GlowingButton href={post.bookUrl || "#"} target="_blank">
+                  <GlowingButton
+                    href={post.bookUrl || "#"}
+                    target="_blank"
+                    aria-label="Go to signup form">
                     Get the Book
                   </GlowingButton>
                 </div>

--- a/src/app/(website)/(main)/books/books.js
+++ b/src/app/(website)/(main)/books/books.js
@@ -9,7 +9,7 @@ export default function Books({ searchParams }) {
       <Container large className="border-l border-r border-neutral-200/10">
         <PageHeader
           title="Hey Rebekah's Book Club"
-          leadText="Must-reads for knowledge workers climbing the ladder or blazing a new trail. These books were chosen for ideas worth a fortune but costing only what's in your library. Recent discoveries include gems to spark creativity, dodge dunderheads, master communication, or pen that memoir—without quitting your day job. One new mind-bending, career-mending page-turner delivered weekly, gratis. Join us?"
+          leadText="Must-reads for knowledge workers climbing the ladder or blazing a new trail. These books were chosen for ideas worth a fortune but costing only what's in your library. One new mind-bending, career-mending page-turner delivered weekly, gratis. Join us?"
           id="books"
           includeForm
         />

--- a/src/app/(website)/(main)/built-with/[slug]/tool.js
+++ b/src/app/(website)/(main)/built-with/[slug]/tool.js
@@ -57,7 +57,7 @@ export default function Tool(props) {
               <GlowingButton
                 href={data.toolUrl || "#"}
                 target="_blank"
-                aria-label="Go to signup form">
+                aria-label="Go to sign-up form">
                 Visit {data.name}
               </GlowingButton>
             </div>{" "}

--- a/src/app/(website)/(main)/built-with/[slug]/tool.js
+++ b/src/app/(website)/(main)/built-with/[slug]/tool.js
@@ -54,7 +54,10 @@ export default function Tool(props) {
           )}
           <div className="mt-12 lg:max-w-xs">
             <div className="mt-6">
-              <GlowingButton href={data.toolUrl || "#"} target="_blank">
+              <GlowingButton
+                href={data.toolUrl || "#"}
+                target="_blank"
+                aria-label="Go to signup form">
                 Visit {data.name}
               </GlowingButton>
             </div>{" "}

--- a/src/app/(website)/(main)/editorial-policy/page.tsx
+++ b/src/app/(website)/(main)/editorial-policy/page.tsx
@@ -4,13 +4,14 @@ import Container from "@/components/container";
 import PageHeader from "@/components/sections/pageheader";
 import { Prose } from "@/components/ui";
 import { getLegalPageBySlug } from "@/sanity/client";
+import { Metadata } from "@/types/types";
 
-export function generateMetadata() {
+export function generateMetadata(): Metadata {
   const title = "Editorial Policy";
   const description =
     "The TL;DR? We're a free daily newsletter for knowledge workers. We write about AI. We don't accept money for affiliate links and always mark paid content.";
 
-  const metadata = {
+  const metadata: Metadata = {
     title,
     description,
     openGraph: {
@@ -28,8 +29,14 @@ export function generateMetadata() {
   return metadata;
 }
 
+interface Post {
+  name?: string;
+  tldr?: string;
+  content?: any;
+}
+
 export default async function EditorialPolicy() {
-  const post = await getLegalPageBySlug("editorial-policy");
+  const post: Post = await getLegalPageBySlug("editorial-policy");
 
   // Fetch the post data and insert it into the component
   const title = post?.name ?? "Default Title";

--- a/src/app/(website)/(main)/privacy/page.tsx
+++ b/src/app/(website)/(main)/privacy/page.tsx
@@ -1,16 +1,18 @@
 import { PortableText } from "@portabletext/react";
+import { ReactElement } from "react";
 
 import Container from "@/components/container";
 import PageHeader from "@/components/sections/pageheader";
 import { Prose } from "@/components/ui";
 import { getLegalPageBySlug } from "@/sanity/client";
+import { Metadata } from "@/types/types";
 
-export function generateMetadata() {
+export function generateMetadata(): Metadata {
   const title = "Privacy Policy";
   const description =
     "We're a privacy-first company. We'll never sell your information and will do everything we can to protect it. Read more details on the whos and the whats.";
 
-  const metadata = {
+  const metadata: Metadata = {
     title,
     description,
     openGraph: {
@@ -28,9 +30,14 @@ export function generateMetadata() {
   return metadata;
 }
 
+interface Post {
+  name?: string;
+  tldr?: string;
+  content?: any;
+}
 
-export default async function Privacy() {
-  const post = await getLegalPageBySlug("privacy");
+export default async function Privacy(): Promise<ReactElement> {
+  const post: Post = await getLegalPageBySlug("privacy");
 
   // Fetch the post data and insert it into the component
   const title = post?.name ?? "Default Title";

--- a/src/app/(website)/(main)/privacy/page.tsx
+++ b/src/app/(website)/(main)/privacy/page.tsx
@@ -51,7 +51,7 @@ export default async function Privacy() {
       </div>
       <div className="mx-auto mb-20 mt-14 flex max-w-screen-xl flex-col gap-5 px-5 md:flex-row">
         <article className="flex-1 ">
-          <Prose className="prose mx-auto max-w-prose">
+          <Prose className="prose mx-auto max-w-prose break-words ">
             <PortableText value={content} />
           </Prose>
         </article>

--- a/src/app/(website)/(main)/terms/page.tsx
+++ b/src/app/(website)/(main)/terms/page.tsx
@@ -1,16 +1,18 @@
 import { PortableText } from "@portabletext/react";
+import { ReactElement } from "react";
 
 import Container from "@/components/container";
 import PageHeader from "@/components/sections/pageheader";
 import { Prose } from "@/components/ui";
 import { getLegalPageBySlug } from "@/sanity/client";
+import { Metadata } from "@/types/types";
 
-export function generateMetadata() {
+export function generateMetadata(): Metadata {
   const title = "Terms of Service";
   const description =
     "Wondering about the fine print? No worries, read Hey Rebekah's Terms of Service for peace of mind. TL;DR version, if you're not happy, we're not happy.";
 
-  const metadata = {
+  const metadata: Metadata = {
     title,
     description,
     openGraph: {
@@ -28,9 +30,14 @@ export function generateMetadata() {
   return metadata;
 }
 
+interface Post {
+  name?: string;
+  tldr?: string;
+  content?: any;
+}
 
-export default async function Terms() {
-  const post = await getLegalPageBySlug("terms");
+export default async function Terms(): Promise<ReactElement> {
+  const post: Post = await getLegalPageBySlug("terms");
 
   // Fetch the post data and insert it into the component
   const title = post?.name ?? "Default Title";

--- a/src/app/(website)/(main)/terms/page.tsx
+++ b/src/app/(website)/(main)/terms/page.tsx
@@ -51,7 +51,7 @@ export default async function Terms() {
       </div>
       <div className="flex flex-col max-w-screen-xl gap-5 px-5 mx-auto mb-20 mt-14 md:flex-row">
         <article className="flex-1 ">
-          <Prose className="mx-auto prose max-w-prose">
+          <Prose className="mx-auto prose max-w-prose break-words">
             <PortableText value={content} />
           </Prose>
         </article>

--- a/src/app/(website)/(rebekah-radice)/layout.tsx
+++ b/src/app/(website)/(rebekah-radice)/layout.tsx
@@ -76,7 +76,7 @@ function Footer() {
 
           <p className="mt-8 text-xs leading-5 text-gray-400 md:order-1 md:mt-0">
             &copy; {new Date().getFullYear()} Hey Rebekah and Rebekah Radice are
-            registered trademakrs of
+            registered trademarks of
             <Link
               href="https://bril.la"
               target="_blank"
@@ -86,7 +86,8 @@ function Footer() {
               {" "}
               BRIL.LA, LLC.
             </Link>
-            &nbsp;All rights reserved.
+            <br className="md:hidden" />
+            &nbsp;All Rights Reserved.
           </p>
         </div>
       </div>

--- a/src/app/(website)/(rebekah-radice)/layout.tsx
+++ b/src/app/(website)/(rebekah-radice)/layout.tsx
@@ -29,12 +29,12 @@ function Navbar() {
             <div className="space-x-4">
               <Link
                 href="/social-blog"
-                className={cx("text-lg leading-6 text-gray-200", hoverStyles)}>
+                className={cx("text-md uppercase leading-6 text-gray-200", hoverStyles)}>
                 Blog
               </Link>
               <Link
                 href="/contact"
-                className={cx("text-lg leading-6 text-gray-200", hoverStyles)}>
+                className={cx("text-md uppercase leading-6 text-gray-200", hoverStyles)}>
                 Contact
               </Link>
             </div>

--- a/src/components/about/email-cta.tsx
+++ b/src/components/about/email-cta.tsx
@@ -21,7 +21,7 @@ function EmailCta(props: Props) {
         </p>
       </div>
       <div className="mt-4 md:mt-5 md:max-w-xs">
-        <GlowingButton variant="link" href="/signup" id="about-cta2">
+        <GlowingButton variant="link" href="/signup" id="about-cta2" aria-label="Go to signup form">
           Level Up
         </GlowingButton>
         <p className="mt-4 text-left text-xs leading-6 text-gray-300">

--- a/src/components/about/email-cta.tsx
+++ b/src/components/about/email-cta.tsx
@@ -21,7 +21,7 @@ function EmailCta(props: Props) {
         </p>
       </div>
       <div className="mt-4 md:mt-5 md:max-w-xs">
-        <GlowingButton variant="link" href="/signup" id="about-cta2" aria-label="Go to signup form">
+        <GlowingButton variant="link" href="/signup" id="about-cta2" aria-label="Go to sign-up form">
           Level Up
         </GlowingButton>
         <p className="mt-4 text-left text-xs leading-6 text-gray-300">

--- a/src/components/blog/sidebar.js
+++ b/src/components/blog/sidebar.js
@@ -36,7 +36,7 @@ function Subscribe({ title, text }) {
           size="md"
           autoWidth={false}
           id="post-side"
-          aria-label="Go to signup form">
+          aria-label="Go to sign-up form">
           Level Up
         </GlowingButton>
       </div>

--- a/src/components/blog/sidebar.js
+++ b/src/components/blog/sidebar.js
@@ -35,7 +35,8 @@ function Subscribe({ title, text }) {
           href="/signup"
           size="md"
           autoWidth={false}
-          id="subscribe-button">
+          id="post-side"
+          aria-label="Go to signup form">
           Level Up
         </GlowingButton>
       </div>

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -146,7 +146,8 @@ export default function Footer() {
                 {" "}
                 BRIL.LA, LLC.
               </Link>
-              &nbsp;All rights reserved.
+              <br className="md:hidden" />
+              &nbsp;All Rights Reserved.
             </p>
 
             <p className="mt-8 text-xs leading-5 text-gray-400 md:order-1 md:mt-0">

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -130,7 +130,11 @@ export default function Footer() {
                 everyday.
               </p>
             </div>
-            <GlowingButton variant="link" href="/signup" id="footer">
+            <GlowingButton
+              variant="link"
+              href="/signup"
+              id="footer"
+              aria-label="Go to signup form">
               Level Up
             </GlowingButton>
           </div>

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -134,7 +134,7 @@ export default function Footer() {
               variant="link"
               href="/signup"
               id="footer"
-              aria-label="Go to signup form">
+              aria-label="Go to sign-up form">
               Level Up
             </GlowingButton>
           </div>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -22,7 +22,7 @@ const Hero: React.FC = () => {
           Join over 338,000 professionals in our community.
         </Lead>
         <div className="mt-8 md:mt-10 md:max-w-xs">
-          <GlowingButton variant="link" href="/signup" id="hero">
+          <GlowingButton variant="link" href="/signup" id="hero" aria-label="Go to signup form">
             Level Up
           </GlowingButton>
         </div>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -22,7 +22,7 @@ const Hero: React.FC = () => {
           Join over 338,000 professionals in our community.
         </Lead>
         <div className="mt-8 md:mt-10 md:max-w-xs">
-          <GlowingButton variant="link" href="/signup" id="hero" aria-label="Go to signup form">
+          <GlowingButton variant="link" href="/signup" id="hero" aria-label="Go to sign-up form">
             Level Up
           </GlowingButton>
         </div>

--- a/src/components/partners/expect-from-us.tsx
+++ b/src/components/partners/expect-from-us.tsx
@@ -1,6 +1,6 @@
 import { CheckIcon } from "@heroicons/react/20/solid";
 
-import { GlowingButton, H2, H3, Lead } from "../ui";
+import { GlowingButton, H3, Lead } from "../ui";
 
 const features = [
   {
@@ -58,7 +58,7 @@ export default function ExpectFromUs(props: Props) {
           <div
             className="col-span-2 pt-16 mx-auto" // eslint-disable-next-line react/jsx-no-bind
             onClick={() => props.scrollToContact()}>
-            <GlowingButton>Become a partner</GlowingButton>
+            <GlowingButton aria-label="Go to partner form">Become a partner</GlowingButton>
           </div>
         </dl>
       </div>

--- a/src/components/partners/expect-from-us.tsx
+++ b/src/components/partners/expect-from-us.tsx
@@ -2,7 +2,7 @@ import { CheckIcon } from "@heroicons/react/20/solid";
 
 import { GlowingButton, H3, Lead } from "../ui";
 
-const features = [
+const benefits = [
   {
     name: "Bespoke content developed just for your brand",
   },
@@ -42,16 +42,16 @@ export default function ExpectFromUs(props: Props) {
           </Lead>
         </div>
         <dl className="grid grid-cols-2 col-span-5 gap-8 md:col-span-3">
-          {features.map((feature) => (
+          {benefits.map((benefit) => (
             <div
-              key={feature.name}
+              key={benefit.name}
               className="relative col-span-2 pl-9 md:col-span-1">
               <dt className="text-xl text-gray-400">
                 <CheckIcon
                   className="absolute left-0 w-5 h-5 font-bold text-gray-400 top-1"
                   aria-hidden="true"
                 />
-                {feature.name}
+                {benefit.name}
               </dt>
             </div>
           ))}

--- a/src/components/partners/index.tsx
+++ b/src/components/partners/index.tsx
@@ -56,7 +56,7 @@ function PartnerPage(props: Props) {
                   className="flex items-center justify-center mt-10 gap-x-6"
                   // eslint-disable-next-line react/jsx-no-bind
                   onClick={() => scrollToContact()}>
-                  <GlowingButton>Become a Partner</GlowingButton>
+                  <GlowingButton aria-label="Go to partner form">Become a Partner</GlowingButton>
                 </div>
               </div>
             </div>

--- a/src/components/partners/looking-for.tsx
+++ b/src/components/partners/looking-for.tsx
@@ -1,6 +1,6 @@
 import { H3, Lead } from "../ui";
 
-const features = [
+const expectations = [
   {
     name: "Exclusive discount",
     description: (
@@ -37,16 +37,16 @@ export default function LookingFor() {
         </div>
         <div className="mx-auto mt-16 max-w-2xl sm:mt-20 lg:mt-24 lg:max-w-none">
           <dl className="grid max-w-xl grid-cols-1 gap-x-8 gap-y-16 lg:max-w-none lg:grid-cols-3">
-            {features.map((feature, i) => (
-              <div key={feature.name} className="flex flex-col">
+            {expectations.map((expectation, i) => (
+              <div key={expectation.name} className="flex flex-col">
                 <dt className="text-xl font-semibold leading-7 text-gray-200">
                   <div className="mb-6 flex h-10 w-10 items-center justify-center rounded-lg bg-slate-900">
                     {i + 1}
                   </div>
-                  {feature.name}
+                  {expectation.name}
                 </dt>
                 <dd className="mt-1 flex flex-auto flex-col text-base leading-7 text-gray-400">
-                  <p className="flex-auto">{feature.description}</p>
+                  <p className="flex-auto">{expectation.description}</p>
                 </dd>
               </div>
             ))}

--- a/src/components/partners/partner-community-stats.tsx
+++ b/src/components/partners/partner-community-stats.tsx
@@ -36,27 +36,27 @@ function PartnerCommunityData() {
               statsTitle: "Community members",
             },
             {
-              id: 1,
+              id: 2,
               statsNumber: "+31,760",
               statsTitle: "Email subscribers",
             },
             {
-              id: 1,
+              id: 3,
               statsNumber: "+7%",
               statsTitle: "Monthly subscriber growth",
             },
             {
-              id: 1,
+              id: 4,
               statsNumber: "63.3%",
               statsTitle: "Subscriber engagement",
             },
             {
-              id: 1,
+              id: 5,
               statsNumber: "100%",
               statsTitle: "Free for knowledge workers",
             },
             {
-              id: 1,
+              id: 6,
               statsNumber: "92",
               statsTitle: "Net Promoter Score",
             },

--- a/src/components/rebekah-radice/contact-rebekah.tsx
+++ b/src/components/rebekah-radice/contact-rebekah.tsx
@@ -248,7 +248,7 @@ function ContactRebekah(props: Props) {
             </div>
             <ReactTurnstile />
             <div className="col-span-2">
-              <GlowingButton type="submit">
+              <GlowingButton aria-label="Submit Form" type="submit">
                 {isLoading ? "Loading..." : "Let's make it happen"}
               </GlowingButton>
               {isSuccess && (

--- a/src/components/rebekah-radice/rebekah-hero.tsx
+++ b/src/components/rebekah-radice/rebekah-hero.tsx
@@ -21,7 +21,7 @@ function RebekahHero(props: Props) {
         className="max-w-sm mx-auto mt-12"
         // eslint-disable-next-line react/jsx-no-bind
         onClick={() => props.scrollToContact()}>
-        <GlowingButton>Still Interested?</GlowingButton>
+        <GlowingButton ariaLabel="Scroll to next section">Still Interested?</GlowingButton>
       </div>
     </div>
   );

--- a/src/components/rebekah-radice/rebekah-services.tsx
+++ b/src/components/rebekah-radice/rebekah-services.tsx
@@ -84,7 +84,7 @@ function RebekahServices() {
               <H4 className="font-bold text-gray-200">{srv.serviceMoto}</H4>
               <Lead className="text-gray-400">{srv.ServiceDesc}</Lead>
               <div className="max-w-sm mt-12">
-                <GlowingButton type="link" href="#contact" size="sm">
+                <GlowingButton type="link" href="#contact" size="sm" ariaLabel="Scroll to Contact Form">
                   {srv.serviceLink}
                 </GlowingButton>
               </div>

--- a/src/components/rebekah-radice/remeber-for.tsx
+++ b/src/components/rebekah-radice/remeber-for.tsx
@@ -40,7 +40,7 @@ const RememberFor = () => {
               accessible.
             </Lead>
             <div className="max-w-sm mt-12">
-              <GlowingButton type="link" href="/signup" aria-label="Go to signup form">
+              <GlowingButton type="link" href="/signup" aria-label="Go to sign-up form">
                 Join hey Rebekah
               </GlowingButton>
             </div>

--- a/src/components/rebekah-radice/remeber-for.tsx
+++ b/src/components/rebekah-radice/remeber-for.tsx
@@ -40,7 +40,7 @@ const RememberFor = () => {
               accessible.
             </Lead>
             <div className="max-w-sm mt-12">
-              <GlowingButton type="link" href="/signup">
+              <GlowingButton type="link" href="/signup" aria-label="Go to signup form">
                 Join hey Rebekah
               </GlowingButton>
             </div>

--- a/src/components/rebekah-radice/remeber-for.tsx
+++ b/src/components/rebekah-radice/remeber-for.tsx
@@ -32,12 +32,7 @@ const RememberFor = () => {
           <div className="sticky text-left text-gray-200 holder__head">
             <H3 as="h2">Hey Rebekah is what I'll be remembered for</H3>
             <Lead className="mt-5 text-gray-400">
-              I launched Hey Rebekah to help freelancers become better at what
-              they do. Everything we create will always be free for readers and
-              the community. Hey Rebekah is a free daily newsletter. It's about
-              to get a whole lot better thanks to machine learning. We're also
-              creating some pretty cool apps to make generative AI more
-              accessible.
+              Hey Rebekah is a free daily newsletter for knowledge workers. I launched it to help professionals bring AI in to their workflows. Everything we produce is free and always will be. It's about to get a whole lot better too thanks to machine learning. We're also creating some pretty cool apps to make generative AI more accessible.
             </Lead>
             <div className="max-w-sm mt-12">
               <GlowingButton type="link" href="/signup" aria-label="Go to sign-up form">
@@ -49,34 +44,31 @@ const RememberFor = () => {
 
         <section className="col-span-4 gap-20 text-left text-gray-200 holder md:col-span-2">
           <div className="holder__head sticky space-y-5 rounded border border-gray-200/10 bg-slate-900 !p-10">
-            <H4 as="h3">Best newsletter for freelancers</H4>
-            <H6 as="h4">Like Morning Brew for freelancers</H6>
+            <H4 as="h3">Best newsletter for AI</H4>
+            <H6 as="h4">Like Morning Brew, but for ChatGPT</H6>
             <Lead className="pb-4 text-gray-400">
               A free daily newsletter. We write about things that help you
-              become better at what you do in 6 minutes or less.
+              become better at what you do with AI.
             </Lead>
           </div>
           <div className="holder__head space-y-5 rounded border border-gray-200/10 bg-slate-900 !p-10">
             <Lead className="w-48 px-2 py-2 text-center border-2 rounded border-gray-200/10 bg-midnight">
               COMING SOON
             </Lead>
-            <H4 as="h3">Generative AI for freelancers</H4>
-            <H6 as="h4">OpenAI x Anthropic fine-tuned for freelancers</H6>
+            <H4 as="h3">Free Generative AI</H4>
+            <H6 as="h4">OpenAI x Anthropic fine-tuned for knowledge workers</H6>
             <Lead className="text-gray-400 ">
-              We've fine-tuned our generative AI for freelancers. Make work
-              easier, boost creativity, get more done, and improve your skills.
+              We created and curated embedded models in a bunch of different fields. It'll save you from fumbling around. You'll get accurate information to get your work done sooner, so you can enjoy more down time.
             </Lead>
           </div>
           <div className="holder__head space-y-5 rounded border border-gray-200/10 bg-slate-900 !p-10">
             <Lead className="w-48 px-2 py-2 text-center border-2 rounded border-gray-200/10 bg-midnight">
               COMING SOON
             </Lead>
-            <H4 as="h3">Free jobs with vetted clients</H4>
-            <H6 as="h4">Like Upwork without the crazy fees</H6>
+            <H4 as="h3">Free Community</H4>
+            <H6 as="h4">Like your favorite social platform but better</H6>
             <Lead className="text-gray-400 ">
-              Get access to no-fee gigs and vetted clients for top-notch job
-              opportunities. But without the hefty fees. Think Upwork if it was
-              free forever.
+              You'll have exclusive access to over 338,000 knowledge workers. Our community will also be supported by top experts, AI influencers, and a few crazy smart people.
             </Lead>
           </div>
           <div className="holder__head space-y-5 rounded border border-gray-200/10 bg-slate-900 !p-10">

--- a/src/components/sections/herowithimage.tsx
+++ b/src/components/sections/herowithimage.tsx
@@ -39,7 +39,7 @@ export function HeroWithImage(props: Props) {
             href="/signup"
             size="md"
             id="about-hero"
-            aria-label="Go to signup form"
+            aria-label="Go to sign-up form"
           >
             Join the Curious
           </GlowingButton>

--- a/src/components/sections/herowithimage.tsx
+++ b/src/components/sections/herowithimage.tsx
@@ -39,6 +39,7 @@ export function HeroWithImage(props: Props) {
             href="/signup"
             size="md"
             id="about-hero"
+            aria-label="Go to signup form"
           >
             Join the Curious
           </GlowingButton>

--- a/src/components/sections/pageheader.tsx
+++ b/src/components/sections/pageheader.tsx
@@ -19,7 +19,7 @@ const PageHeader: React.FC<PageHeaderProps> = ({ title, leadText, id, includeFor
         <Lead className="mt-6 text-gray-400">{leadText}</Lead>
         {includeForm && (
           <div className="mx-auto mt-8 md:mt-10 md:max-w-xs">
-            <GlowingButton variant="link" href="/signup" id={id}>
+            <GlowingButton variant="link" href="/signup" aria-label="Go to signup form" id={id}>
               Level Up
             </GlowingButton>
           </div>

--- a/src/components/sections/pageheader.tsx
+++ b/src/components/sections/pageheader.tsx
@@ -19,7 +19,7 @@ const PageHeader: React.FC<PageHeaderProps> = ({ title, leadText, id, includeFor
         <Lead className="mt-6 text-gray-400">{leadText}</Lead>
         {includeForm && (
           <div className="mx-auto mt-8 md:mt-10 md:max-w-xs">
-            <GlowingButton variant="link" href="/signup" aria-label="Go to signup form" id={id}>
+            <GlowingButton variant="link" href="/signup" aria-label="Go to sign-up form" id={id}>
               Level Up
             </GlowingButton>
           </div>

--- a/src/components/sections/signupheader.tsx
+++ b/src/components/sections/signupheader.tsx
@@ -9,10 +9,10 @@ interface PageHeaderProps {
 }
 
 const testimonialArray = [
-  "  This is just the best thing I've ever read! ~ Nancy (Rebekah's mom)",
+  "  This is the best thing ever! ~ Nancy (Rebekah's mom)",
   "Hey Rebekah is smart AF! ~ Cam (Rebekah's son)",
-  "I have to read this newsletter everyday! ~ Chris (Rebekah's son)",
-  "Hey Rebekah, grab me some chips while you're there? ~ Dean (Rebekah's husband)",
+  "I have to read it everyday! ~ Chris (Rebekah's son)",
+  "Grab me some chips? ~ Dean (Rebekah's husband)",
 ];
 
 const SignupHeader: React.FC<PageHeaderProps> = ({ title, leadText }) => {
@@ -22,7 +22,7 @@ const SignupHeader: React.FC<PageHeaderProps> = ({ title, leadText }) => {
         <H1 className="text-gray-200">{title}</H1>
         {leadText && <Lead className="mt-6 text-gray-400">{leadText}</Lead>}
 
-        <div className="mt-6">
+        <div className="mt-4">
           <RotatingText items={testimonialArray} />
         </div>
       </div>

--- a/src/components/shared/rotatingtext.tsx
+++ b/src/components/shared/rotatingtext.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 const RotatingText = ({ items }: Props) => {
   return (
-    <p className={`min-h-[4rem] text-center text-lg text-white/50`}>
+    <p className={`min-h-[4rem] text-xs text-center md:text-lg text-white/50`}>
       <Textra
         data={items}
         effect="simple"

--- a/src/components/ui/email-form.tsx
+++ b/src/components/ui/email-form.tsx
@@ -85,7 +85,7 @@ function EmailForm() {
           <div className="col-span-4 md:col-span-2">
             <input
               type="text"
-              placeholder="rebekah"
+              placeholder="First name"
               {...(register && register("firstName"))}
               className="w-full text-gray-200 border-2 border-black rounded border-neutral-200/10 bg-slate-900 placeholder:text-zinc-400 focus:border-pink focus:ring-pink"
             />
@@ -98,7 +98,7 @@ function EmailForm() {
           <div className="col-span-4 md:col-span-2">
             <input
               type="text"
-              placeholder="Radice"
+              placeholder="Last name"
               {...register("lastName")}
               className="w-full text-gray-200 border-2 border-black rounded border-neutral-200/10 bg-slate-900 placeholder:text-zinc-400 focus:border-pink focus:ring-pink"
             />
@@ -111,7 +111,7 @@ function EmailForm() {
           <div className="col-span-4 md:col-span-2">
             <input
               type="text"
-              placeholder="email"
+              placeholder="Email"
               {...register("email")}
               className="w-full text-gray-200 border-2 border-black rounded border-neutral-200/10 bg-slate-900 placeholder:text-zinc-400 focus:border-pink focus:ring-pink"
             />
@@ -124,7 +124,7 @@ function EmailForm() {
           <div className="col-span-4 md:col-span-2">
             <input
               type="text"
-              placeholder="phoneNumber"
+              placeholder="Phone number"
               {...register("phoneNumber")}
               className="w-full text-gray-200 border-2 border-black rounded border-neutral-200/10 bg-slate-900 placeholder:text-zinc-400 focus:border-pink focus:ring-pink"
             />
@@ -137,7 +137,7 @@ function EmailForm() {
           <div className="col-span-4 md:col-span-2">
             <input
               type="text"
-              placeholder="jobTitle"
+              placeholder="Job title"
               {...register("jobTitle")}
               className="w-full text-gray-200 border-2 border-black rounded border-neutral-200/10 bg-slate-900 placeholder:text-zinc-400 focus:border-pink focus:ring-pink"
             />
@@ -150,7 +150,7 @@ function EmailForm() {
           <div className="col-span-4 md:col-span-2">
             <input
               type="text"
-              placeholder="company"
+              placeholder="Company name"
               {...register("company")}
               className="w-full text-gray-200 border-2 border-black rounded border-neutral-200/10 bg-slate-900 placeholder:text-zinc-400 focus:border-pink focus:ring-pink"
             />
@@ -158,7 +158,7 @@ function EmailForm() {
           <div className="col-span-4">
             <input
               type="text"
-              placeholder="companyUrl"
+              placeholder="Website"
               {...register("companyUrl")}
               className="w-full text-gray-200 border-2 border-black rounded border-neutral-200/10 bg-slate-900 placeholder:text-zinc-400 focus:border-pink focus:ring-pink"
             />
@@ -166,7 +166,7 @@ function EmailForm() {
           <div className="col-span-4">
             <textarea
               {...register("message")}
-              placeholder="Message"
+              placeholder="Your message"
               className="w-full text-gray-200 border-2 border-black rounded border-neutral-200/10 bg-slate-900 placeholder:text-zinc-400 focus:border-pink focus:ring-pink"
             />
             {errors.message && (

--- a/src/components/ui/glowingButton.tsx
+++ b/src/components/ui/glowingButton.tsx
@@ -48,6 +48,7 @@ interface GlowingButtonProps {
   children: React.ReactNode;
   autoWidth?: boolean;
   id?: string;
+  ariaLabel?: string;
 }
 
 // Main component for the glowing button
@@ -57,6 +58,7 @@ const GlowingButton: React.FC<GlowingButtonProps> = ({
   size = "md",
   children,
   autoWidth,
+  ariaLabel,
   ...props
 }) => {
   // Wrapper is a button or a link based on the variant prop
@@ -71,6 +73,7 @@ const GlowingButton: React.FC<GlowingButtonProps> = ({
         <GradientBackground />
         <Wrapper
           className={cx(!autoWidth && "w-full")}
+          aria-label={ariaLabel}
           {...wrapperProps}
           {...props}>
           <ButtonContent size={size}>{children}</ButtonContent>

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -109,3 +109,18 @@ export interface GroupedSitemapData {
   socialBlog: SitemapData[];
   tools: SitemapData[];
 }
+
+export interface Metadata {
+  title: string;
+  description: string;
+  openGraph: {
+    title: string;
+    description: string;
+    images: string;
+  };
+  twitter: {
+    title: string;
+    description: string;
+    images: string;
+  };
+}


### PR DESCRIPTION
- pushed the needle forward on a11y because we can never do enough, can't believe we missed so many ARIA labels
- made grammarly proud by cleaning up typos
- addressed Rebekah's OCD by making form labels and placeholders consistent, reminder to get @samuelwondimu a grammarly subscription
- reduced the number of console errors on the Partner page because every key wants to be 1
- had to modify the prose div class because our terms and privacy policies include the world's longest links
- some minor buffing and waxing of styles throughout
- practiced my TS but then got lazy and included an `any`