### PR TITLE
fix: internal link blockContent component Link T-12446

### DIFF
--- a/src/components/shared/post/PortableText/PortableText.js
+++ b/src/components/shared/post/PortableText/PortableText.js
@@ -43,7 +43,7 @@ const components = {
       );
     },
     internalLink: ({ children, value }) => {
-      return <Link href={`/docs/${value.slug.current}`}>{children}</Link>;
+      return <Link href={`/docs/${value?.slug?.current}`}>{children}</Link>;
     },
   },
 };


### PR DESCRIPTION
fix: blockContent to handle empty internal links

failing currently on some faqs

Link T-12446